### PR TITLE
Fix array casting

### DIFF
--- a/src/Traits/EncryptableDbAttribute.php
+++ b/src/Traits/EncryptableDbAttribute.php
@@ -64,6 +64,10 @@ trait EncryptableDbAttribute
             return parent::setAttribute($key, $value);
         }
 
+        if ($this->isJsonCastable($key) && !is_null($value)) {
+            $value = $this->castAttributeAsJson($key, $value);
+        }
+
         $value = $this->encrypt($value);
 
         return parent::setAttribute($key, $value);


### PR DESCRIPTION
Fixes `json_decode() expects parameter 1 to be string, array given {"exception":"[object] (ErrorException(code: 0): json_decode() expects parameter 1 to be string, array given at /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php:902)`